### PR TITLE
Adds nifty feature to evolve choropleth in time.

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -122,9 +122,21 @@
 /*Input Slider Play Controls*/
 #play-controls {
     width: 100%;
+    display: inline-flex;
+}
+#play-left-controls {
+    width: 95px;
+}
+#play-right-output { 
+    float: right;
+}
+#play-slider {
+    width: 100%;
 }
 #choropleth-play-output {
     padding-left: 15px;
+    width: 150px;
+    float:right;
 }
 #choropleth-play-pause-button {
     background-color: #50555C;
@@ -132,15 +144,21 @@
     border: 0px solid #000000;
     padding: 3px 3px 3px 3px;
 }
+#choropleth-force-today-button {
+    background-color: #50555C;
+    color: #1890ff;
+    border: 0px solid #000000;
+    padding: 3px 3px 3px 3px;   
+}
 input[type=range] {
-  margin: 10px 0;
-  width: 350px;
+    margin-top: 3px;
+    width:100%;
 }
 input[type=range]:focus {
   outline: none;
 }
 input[type=range]::-webkit-slider-runnable-track {
-  width: 350px;
+  /*width: 350px;*/
   height: 14px;
   cursor: pointer;
   animate: 0.2s;
@@ -162,7 +180,7 @@ input[type=range]:focus::-webkit-slider-runnable-track {
   background: #50555C;
 }
 input[type=range]::-moz-range-track {
-  width: 350px;
+  /*width: 350px;*/
   height: 14px;
   cursor: pointer;
   animate: 0.2s;
@@ -181,7 +199,7 @@ input[type=range]::-moz-range-thumb {
   cursor: pointer;
 }
 input[type=range]::-ms-track {
-  width: 350px;
+  /*width: 350px;*/
   height: 14px;
   cursor: pointer;
   animate: 0.2s;

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -119,9 +119,107 @@
     border-radius: 3rem;
 }
 
+/*Input Slider Play Controls*/
+#play-controls {
+    width: 100%;
+}
+#choropleth-play-output {
+    padding-left: 15px;
+}
+#choropleth-play-pause-button {
+    background-color: #50555C;
+    color: #1890ff;
+    border: 0px solid #000000;
+    padding: 3px 3px 3px 3px;
+}
+input[type=range] {
+  margin: 10px 0;
+  width: 350px;
+}
+input[type=range]:focus {
+  outline: none;
+}
+input[type=range]::-webkit-slider-runnable-track {
+  width: 350px;
+  height: 14px;
+  cursor: pointer;
+  animate: 0.2s;
+  box-shadow: 1px 1px 1px #50555C;
+  background: #50555C;
+  border-radius: 14px;
+  border: 0px solid #000000;
+}
+input[type=range]::-webkit-slider-thumb {
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 20px;
+  width: 40px;
+  border-radius: 12px;
+  background: #529DE1;
+  cursor: pointer;
+}
+input[type=range]:focus::-webkit-slider-runnable-track {
+  background: #50555C;
+}
+input[type=range]::-moz-range-track {
+  width: 350px;
+  height: 14px;
+  cursor: pointer;
+  animate: 0.2s;
+  box-shadow: 1px 1px 1px #50555C;
+  background: #50555C;
+  border-radius: 14px;
+  border: 0px solid #000000;
+}
+input[type=range]::-moz-range-thumb {
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 20px;
+  width: 40px;
+  border-radius: 12px;
+  background: #529DE1;
+  cursor: pointer;
+}
+input[type=range]::-ms-track {
+  width: 350px;
+  height: 14px;
+  cursor: pointer;
+  animate: 0.2s;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+input[type=range]::-ms-fill-lower {
+  background: #50555C;
+  border: 0px solid #000000;
+  border-radius: 28px;
+  box-shadow: 1px 1px 1px #50555C;
+}
+input[type=range]::-ms-fill-upper {
+  background: #50555C;
+  border: 0px solid #000000;
+  border-radius: 28px;
+  box-shadow: 1px 1px 1px #50555C;
+}
+input[type=range]::-ms-thumb {
+  margin-top: 1px;
+  box-shadow: 0px 0px 0px #000000;
+  border: 0px solid #000000;
+  height: 20px;
+  width: 40px;
+  border-radius: 12px;
+  background: #529DE1;
+  cursor: pointer;
+}
+input[type=range]:focus::-ms-fill-lower {
+  background: #50555C;
+}
+input[type=range]:focus::-ms-fill-upper {
+  background: #50555C;
+}
 
 /* Sortable */
-.sortable th {
+#sortable th {
     cursor: pointer;
 }
 

--- a/app/index.html
+++ b/app/index.html
@@ -175,9 +175,16 @@
                                 </form>
                                 <div id="map" class="h-350 h-lg-450"></div>
                                 <div id="play-controls">
-                                   <button id="choropleth-play-pause-button" class="fa fa-play" title="play"></button>
-                                   <input id="choropleth-play-range" type="range" value="0" min="0" max="300"></input>
-                                   <output id="choropleth-play-output" for="play-range" name="day">Today</output>
+                                   <div id="play-left-controls">
+                                     <button id="choropleth-force-today-button" class="fas fa-fast-forward" title="today"></button>
+                                     <button id="choropleth-play-pause-button" class="fa fa-play" title="play"></button>
+                                   </div>
+                                   <div id="play-slider">
+                                     <input id="choropleth-play-range" type="range" value="0" min="0" max="300"></input>
+                                   </div>
+                                   <div id="play-right-output">
+                                     <output id="choropleth-play-output" for="play-range" name="day">Today</output>
+                                   </div>
                                 </div>
                             </div>
                         </div>

--- a/app/index.html
+++ b/app/index.html
@@ -174,6 +174,11 @@
                                     </div>
                                 </form>
                                 <div id="map" class="h-350 h-lg-450"></div>
+                                <div id="play-controls">
+                                   <button id="choropleth-play-pause-button" class="fa fa-play" title="play"></button>
+                                   <input id="choropleth-play-range" type="range" value="0" min="0" max="300"></input>
+                                   <output id="choropleth-play-output" for="play-range" name="day">Today</output>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -565,6 +565,7 @@ import config from './config.js';
         _dc.ageSexDistBarChart.update();
         _dc.cantonalComparisonBarChart.update().updateChart();
       });
+  // Pressing play or pause on the choropleth will play/pause map
   document
       .getElementById('choropleth-play-pause-button')
       .addEventListener('click', (event) => {
@@ -573,11 +574,11 @@ import config from './config.js';
         // otherwise, we pause.
         if (_dc.choropleth.sequenceTimer === undefined) {
           updateButtonToShowPause(button);
-          // Every half second we update the map to the next day.
+          // Every one-third second we update the map to the next day.
           _dc.choropleth.sequenceTimer = setInterval(function () {
               let range = document.getElementById('choropleth-play-range');
               if (parseInt(range.value) < parseInt(range.max)) {
-                const daysAgo = parseInt(range.max) - parseInt(range.value) - 1;
+                const daysAgo = parseInt(range.max) - parseInt(range.value);
                 // Update the choropleth to the new day
                 _dc.choropleth.update(_dc.s, _dc.data, daysAgo);
                 // Update the play bar to the new day
@@ -588,6 +589,11 @@ import config from './config.js';
               } else {
                 // When we have arrived at the present day: today, we pause.
                 pauseTheMap(button, _dc.choropleth);
+                // Update the choropleth to today
+                _dc.choropleth.update(_dc.s, _dc.data, 0);
+                // Update the play bar to today
+                updateTimeline(0, 
+                  document.getElementById('choropleth-play-output'));
                 // Reset the play bar.
                 range.value = range.min;
               }
@@ -596,17 +602,29 @@ import config from './config.js';
           pauseTheMap(button, _dc.choropleth);
        }
       });
-
+  // Dragging the input on the play bar choropleth will set the day.
   document
       .getElementById('choropleth-play-range')
       .addEventListener('input', (event) => {
         let range = document.getElementById('choropleth-play-range');  
-        let daysAgo = parseInt(range.max) - parseInt(range.value) - 1;
+        let daysAgo = parseInt(range.max) - parseInt(range.value);
         // Update the choropleth to the new day
         _dc.choropleth.update(_dc.s, _dc.data, daysAgo);
         // Update the play bar to the new day
         updateTimeline(daysAgo, 
           document.getElementById('choropleth-play-output'));            
+      });
+  // Hitting the fast forward button will push the choropleth to today.
+  document
+    .getElementById('choropleth-force-today-button')
+    .addEventListener('click', (event) => {
+        let range = document.getElementById('choropleth-play-range');  
+        // Update the choropleth to today
+        _dc.choropleth.update(_dc.s, _dc.data, 0);
+        // Update the play bar to today
+        updateTimeline(0, document.getElementById('choropleth-play-output'));
+        // Update the play bar to reset value.
+        range.value = range.min;      
       });
 
   document
@@ -741,8 +759,9 @@ import config from './config.js';
     let displayDate = new Date(todaysDate);
     displayDate.setDate(todaysDate.getDate() - daysAgoToUpdate);
     const options = { year: 'numeric', month: 'long', day: 'numeric' };
+    const language = persistentState.language != 'none' ? persistentState.language : "en";
     timelineToUpdate.innerHTML = displayDate.toLocaleDateString(
-      persistentState.language + "-CH", options);
+      language + "-CH", options);
   }
 
   // Changes the play bar button to be a play icon and stops the
@@ -800,7 +819,7 @@ import config from './config.js';
           saveState();
           location.reload();
           return false;
-        },
+        }
       }, language));
     }
   }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -623,8 +623,11 @@ import config from './config.js';
         _dc.choropleth.update(_dc.s, _dc.data, 0);
         // Update the play bar to today
         updateTimeline(0, document.getElementById('choropleth-play-output'));
+        // If we are playing, stop playing.
+        pauseTheMap(document.getElementById('choropleth-play-pause-button'),
+            _dc.choropleth);
         // Update the play bar to reset value.
-        range.value = range.min;      
+        range.value = range.min;   
       });
 
   document

--- a/app/js/choropleth.js
+++ b/app/js/choropleth.js
@@ -131,27 +131,34 @@ export default class Choropleth {
 
       that.mapReadyCallback();
     });
-  }
+  };
 
-  update(state, data) {
+  update(state, data, date_offset) {
+    const maxValueForSelector = {
+      'cases': 1000,
+      'fatalities': 30,
+      'hospitalizedTotal': 50,
+      'hospitalized': 30,
+      'icu': 20,
+      'vent': 20,
+    };
     const chart = getChart(this.container);
     const rowToday = getRow(
         data[state.daily_variable_select],
-        state.daily_date,
+        getTargetCoutryDate(0 + date_offset),
     );
     const rowYesterday = getRow(
         data[state.daily_variable_select],
-        getTargetCoutryDate(1),
+        getTargetCoutryDate(1 + date_offset),
     );
     const rowLastWeek = getRow(
         data[state.daily_variable_select],
-        getTargetCoutryDate(7),
+        getTargetCoutryDate(7 + date_offset),
     );
     const seriesData = [];
     let suffix = '_diff';
     if (state.daily_total) suffix = '';
     if (state.daily_per_capita) suffix += '_pc';
-
     for (const canton of cantons) {
       if (canton.id === 'CH') continue;
       const property = canton.id + suffix;
@@ -167,6 +174,30 @@ export default class Choropleth {
       name: 'Cases',
       data: seriesData,
     });
+    // Fixes the scalebar when we play through
+    // the different dates instead of having
+    // the color bar be dynamically set.
+    if (date_offset > 0) {
+      chart.update({
+        colorAxis: {
+          stops: [
+            [0, '#003f5c'],
+            [0.5, '#f95d6a'],
+            [1.0, '#c80815'],
+          ],
+          max: maxValueForSelector[state.daily_variable_select],
+        }});
+    } else {
+      chart.update({
+        colorAxis: {
+          stops: [
+            [0, '#003f5c'],
+            [1.0, '#f95d6a'],
+          ],
+          max: null,
+        }});
+    }
     chart.redraw();
   };
 }
+


### PR DESCRIPTION
Hello daenuprobst!

I'm a fan of your work. In this PR I've added a feature to the cantonal map: A play button at the bottom which will evolve the map at 3 fps through each day of the pandemic for the selected data point (defaulting to cases). 

<img width="673" alt="Screen Shot 2020-11-25 at 2 30 06 PM" src="https://user-images.githubusercontent.com/4206447/100288520-b7484c80-2f2b-11eb-85c3-c0b530096d8d.png">

A few design choices:
* The dates are also localized according to the provided language -- since country is unavailable, I assume Swiss. 
* Without fixing the colorAxis bar, the bar tends to jump around making the "progress through time" effect I was aiming for difficult to read. When fixing the colorAxis bar, because the most recent surge in cases/hospitalizations is so high, the result was the map just dully remaining blue through time until ~Oct -- I decided to adjust the colorAxis when the play button is playing to include the darker shade of red to make the playthrough more visually interesting. 
* The max-range at which to fix the colorAxis is unfortunately hard coded -- one could iterate through all the days to find the maximum associated with the particular facet, but I decided the latency implications were not worthwhile and instead hardcoded the values.
* I decided not to change the "Today's Data" header and correspondingly left default behavior for the map on page load identical. The user could find this confusing if they mess with the toggle and the header still reads "Today's Data" but I'm not sure if that's a major issue.
* I chose 2020 Feb 27 as the "beginning of the pandemic" for the sake of this graphic. At this point was when multiple cantons start having consistent data.
* I tried my best to mimick the color scheme with the play slider.

_Merci vilmal 🤡_ 

Best,
magixsno


