### PR TITLE
Fix weekly hospitalization calculation

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -667,13 +667,14 @@ import config from './config.js';
         26,
     );
 
-    const weeklyCases = backwardsResample(data.cases.CH_diff, 7, 7, true, 2);
-    const weeklyFatalities = backwardsResample(data.fatalities.CH_diff, 7, 7, true, 2);
+    const weeklyCases = backwardsResample(
+        data.cases.CH_diff, 7, 7, true, 2,
+    );
+    const weeklyFatalities = backwardsResample(
+        data.fatalities.CH_diff, 7, 7, true, 2,
+    );
     const weeklyHospitalizations = backwardsResample(
-        data.hospitalizedTotal.CH_diff,
-        7,
-        7,
-        2,
+        data.hospitalizedTotal.CH_diff, 7, 7, true, 2,
     );
 
     initSummary(


### PR DESCRIPTION
The call to `backwardsResample` for hospitalizations is missing a function argument (`true`), thus not computing the latest two samples only, which in the end results in incorrect data being displayed.

I also took the liberty to change the formatting to be consistent between these three calls, which should make it easier to spot such mistakes (not quite from the rest of the code what the "globally preferred" formatting is).