### PR TITLE
Skip todays data while incomplete

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -3,7 +3,7 @@ import DailyAdaptiveChart from './daily-adaptive-chart.js';
 import Choropleth from './choropleth.js';
 import {cantons} from './cantons.js';
 import {
-  getRow, getField, getTargetCoutryDate, backwardsResample,
+  getRow, getField, getTargetCoutryDate, backwardsResample, dataTodayIsIncomplete,
 } from './helpers.js';
 import LineChart from './line-chart.js';
 import BarChart from './bar-chart.js';
@@ -667,31 +667,42 @@ import config from './config.js';
         26,
     );
 
-    const weeklyCases = backwardsResample(data.cases.CH_diff, 7, 7, true, 2);
-    const weeklyFatalities = backwardsResample(data.fatalities.CH_diff, 7, 7, true, 2);
+    let intv = 7;
+    let skip = 0;
+    for (const variable of ["cases", "fatalities", "hospitalizedTotal"]) {
+      if (dataTodayIsIncomplete(data[variable], "CH", "_diff")) {
+        skip++;
+        break;
+      }
+    }
+    const weeklyCases = backwardsResample(
+      data.cases.CH_diff, intv, intv, true, 2, skip,
+    );
+    const weeklyFatalities = backwardsResample(
+      data.fatalities.CH_diff, intv, intv, true, 2, skip,
+    );
     const weeklyHospitalizations = backwardsResample(
-        data.hospitalizedTotal.CH_diff,
-        7,
-        7,
-        2,
+      data.hospitalizedTotal.CH_diff, intv, intv, true, 2, skip,
     );
 
     initSummary(
-        'summary-week',
-        getTargetCoutryDate(6, true) + '–' + getTargetCoutryDate(0, true) + ' Ø',
-        null,
-        weeklyCases[1][1],
-        weeklyFatalities[1][1],
-        weeklyHospitalizations[1][1],
+      'summary-week',
+      (getTargetCoutryDate(intv + skip - 1, true) + '–'
+       + getTargetCoutryDate(skip, true) + ' Ø'),
+      null,
+      weeklyCases[1][1],
+      weeklyFatalities[1][1],
+      weeklyHospitalizations[1][1],
     );
 
     initSummary(
-        'summary-previous-week',
-        getTargetCoutryDate(13, true) + '–' + getTargetCoutryDate(7, true) + ' Ø',
-        null,
-        weeklyCases[0][1],
-        weeklyFatalities[0][1],
-        weeklyHospitalizations[0][1],
+      'summary-previous-week',
+      (getTargetCoutryDate(2 * intv + skip - 1, true) + '–'
+       + getTargetCoutryDate(intv + skip, true) + ' Ø'),
+      null,
+      weeklyCases[0][1],
+      weeklyFatalities[0][1],
+      weeklyHospitalizations[0][1],
     );
   }
 

--- a/app/js/daily-adaptive-chart.js
+++ b/app/js/daily-adaptive-chart.js
@@ -1,4 +1,7 @@
-import {getTargetCoutryDate, getChart, backwardsResample, roundColumn} from './helpers.js';
+import {
+  getTargetCoutryDate, getChart, backwardsResample, roundColumn,
+  dataTodayIsIncomplete,
+} from './helpers.js';
 
 export default class DailyAdaptiveChart {
   constructor(container, selectionChangedCallback) {
@@ -132,7 +135,8 @@ export default class DailyAdaptiveChart {
         'daily.title.' + state.daily_variable_select,
     )} ${_dc.t('cantons.' + state.daily_canton)}`;
 
-    let values = data[state.daily_variable_select][state.daily_canton + suffix]
+    let cantonalValues = data[state.daily_variable_select];
+    let values = cantonalValues[state.daily_canton + suffix];
 
     chart.series[0].update({
       type: suffix.includes('diff') ? 'column' : 'area',
@@ -141,6 +145,10 @@ export default class DailyAdaptiveChart {
     });
 
     if (suffix.includes('diff')) {
+      let skip = 3;
+      if (dataTodayIsIncomplete(cantonalValues, state.daily_canton, suffix)) {
+        skip++;
+      }
       chart.series[1].update({
         type: 'line',
         dashStyle: 'longdash',
@@ -148,7 +156,7 @@ export default class DailyAdaptiveChart {
         color: '#ffffff',
         marker: { enabled: false },
         name: _dc.t('daily.seven_day_avg') + ' ' + state.daily_canton,
-        data: roundColumn(backwardsResample(values.slice(0, -3), 7, 1, false), 3),
+        data: roundColumn(backwardsResample(values.slice(0, -skip), 7, 1, false), 3),
       });
     } else {
       chart.series[1].update({

--- a/app/js/helpers.js
+++ b/app/js/helpers.js
@@ -1,3 +1,5 @@
+import {cantons} from './cantons.js';
+
 // EXTREMELY basic (but fast) CSS parser for number and dates ONLY.
 // Do not use with just any data, it will explode spectacularely.
 function parseCSV(text, sep = ',') {
@@ -297,6 +299,18 @@ function extend(out) {
   return out;
 };
 
+function dataTodayIsIncomplete(variableData, canton, suffix) {
+  let todayIncomplete = (v) => {
+    return v[v.length - 1][1] == null && v[v.length - 1 - 7][1] != null;
+  };
+  if (canton !== "CH") {
+    return todayIncomplete(variableData[canton + suffix]);
+  }
+  return cantons.some((c) => {
+    return todayIncomplete(variableData[c.id + suffix]);
+  });
+}
+
 export {
   readCSV,
   getRow,
@@ -312,4 +326,5 @@ export {
   backwardsResample,
   getUserLanguage,
   extend,
+  dataTodayIsIncomplete,
 };


### PR DESCRIPTION
For a big part of the present day there's no data (or it's incomplete for "CH"), which makes the comparison of the two previous weeks less representative and skews the last point of the average. Thus I propose to "skip today" in that case, showing the summaries up to yesterday and excluding one more point from the average.