### PR TITLE
Use average not sum (default) for grouped bars in cases-plot for all view

### DIFF
--- a/app/js/daily-adaptive-chart.js
+++ b/app/js/daily-adaptive-chart.js
@@ -44,6 +44,9 @@ export default class DailyAdaptiveChart {
               },
             },
           },
+          dataGrouping: {
+            approximation: "average",
+          },
         },
         column: {
           borderWidth: 0,

--- a/app/js/data.js
+++ b/app/js/data.js
@@ -19,7 +19,7 @@ async function getCases() {
     df[canton + '_pc'] = forwardFill(df[canton + '_pc']);
   }
 
-  // Multiply per capity columns to get per 10,000 values
+  // Multiply per capity columns to get per 100,000 values
   Object.keys(df).forEach(function(key, index) {
     if (key.includes('_pc')) {
       df[key] = multiplyColumn(df[key], 100000);


### PR DESCRIPTION
The "all view" of the cases chart automatically groups/aggregates bars into weeks and uses the sum of the days by default. That's clearly not what is desired for this plot (e.g. peak value beginning of Nov is ~8k correctly, ~50k in the all view at the moment).

Also found an unrelated comment typo.