### PR TITLE
Add missing countries to EN, DE, FR, IT, ES

### DIFF
--- a/app/i18n/de.json
+++ b/app/i18n/de.json
@@ -432,6 +432,16 @@
         "Macedonia": "Mazedonien",
         "China": "China",
         "Seychelles": "Seychellen",
-        "Vanuatu": "Vanuatu"
+        "Vanuatu": "Vanuatu",
+        "North Macedonia": "Nordmazedonien",
+        "Czechia": "Tschechien",
+        "European Union": "Europäische Union",
+        "Europe": "Europa",
+        "South America": "Südamerika",
+        "North America": "Nordamerika",
+        "Asia": "Asien",
+        "Africa": "Afrika",
+        "Oceania": "Ozeanien",
+        "Eswatini": "Swasiland"
     }
 }

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -432,6 +432,16 @@
     "Macedonia": "Macedonia",
     "China": "China",
     "Seychelles": "Seychelles",
-    "Vanuatu": "Vanuatu"
+    "Vanuatu": "Vanuatu",
+    "North Macedonia": "North Macedonia",
+    "Czechia": "Czechia",
+    "European Union": "European Union",
+    "Europe": "Europe",
+    "South America": "South America",
+    "North America": "North America",
+    "Asia": "Asia",
+    "Africa": "Africa",
+    "Oceania": "Oceania",
+    "Eswatini": "Eswatini"
   }
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -432,6 +432,16 @@
         "Macedonia": "macedonia",
         "China": "China",
         "Seychelles": "Seychelles",
-        "Vanuatu": "Vanuatu"
+        "Vanuatu": "Vanuatu",
+        "North Macedonia": "Macedonia del Norte",
+        "Czechia": "Chequia",
+        "European Union": "Unión Europea",
+        "Europe": "Europa",
+        "South America": "América del Sur",
+        "North America": "América del Norte",
+        "Asia": "Asia",
+        "Africa": "Africa",
+        "Oceania": "Oceanía",
+        "Eswatini": "Eswatini"
     }
 }

--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -432,6 +432,16 @@
         "Macedonia": "Macédoine",
         "China": "Chine",
         "Seychelles": "Seychelles",
-        "Vanuatu": "Vanuatu"
+        "Vanuatu": "Vanuatu",
+        "North Macedonia": "Macédoine du Nord",
+        "Czechia": "Tchéquie",
+        "European Union": "Union Européenne",
+        "Europe": "Europe",
+        "South America": "Amérique du Sud",
+        "North America": "Amérique du Nord",
+        "Asia": "Asie",
+        "Africa": "Afrique",
+        "Oceania": "Océanie",
+        "Eswatini": "Eswatini"
     }
 }

--- a/app/i18n/it.json
+++ b/app/i18n/it.json
@@ -432,6 +432,16 @@
         "Macedonia": "Macedonia",
         "China": "Cina",
         "Seychelles": "Seychelles",
-        "Vanuatu": "Vanuatu"
+        "Vanuatu": "Vanuatu",
+        "North Macedonia": "Macedonia del Nord",
+        "Czechia": "Czechia",
+        "European Union": "Unione Europea",
+        "Europe": "Europa",
+        "South America": "America del Sud",
+        "North America": "America del Nord",
+        "Asia": "Asia",
+        "Africa": "Africa",
+        "Oceania": "Oceania",
+        "Eswatini": "Eswatini"
     }
 }

--- a/translate/countries.json
+++ b/translate/countries.json
@@ -214,5 +214,15 @@
   "Macedonia": "Macedonia",
   "China": "China",
   "Seychelles": "Seychelles",
-  "Vanuatu": "Vanuatu"
+  "Vanuatu": "Vanuatu",
+  "North Macedonia": "North Macedonia",
+  "Czechia": "Czechia",
+  "European Union": "European Union",
+  "Europe": "Europe",
+  "South America": "South America",
+  "North America": "North America",
+  "Asia": "Asia",
+  "Africa": "Africa",
+  "Oceania": "Oceania",
+  "Eswatini": "Eswatini"
 }


### PR DESCRIPTION
## Descripton of Change

I checked at [owid/covid-19-data](https://github.com/owid/covid-19-data/blob/master/public/data/latest/owid-covid-latest.csv) which country descriptions are missing.
=> I inserted them to the `en` and `de` country `json` file.

closes #15 

PS: CI tests look fine. _Luxembourg_ and _Rwanda_ are listed twice, once with country name and once without. Seems to be a different bug.