### PR TITLE
Remove "le" in Portugal's name

### DIFF
--- a/app/i18n/fr.json
+++ b/app/i18n/fr.json
@@ -321,7 +321,7 @@
         "Qatar": "Qatar",
         "Kyrgyzstan": "Kirghizistan",
         "Netherlands": "Pays-Bas",
-        "Portugal": "le Portugal",
+        "Portugal": "Portugal",
         "Central African Republic": "République centrafricaine",
         "Croatia": "Croatie",
         "Cote d'Ivoire": "Côte d'Ivoire",


### PR DESCRIPTION
For some reason the Portugal translation has a "le" before it's name.